### PR TITLE
Fixing thread start_routine signatures in tests

### DIFF
--- a/conformance/interfaces/pthread_attr_destroy/1-1.c
+++ b/conformance/interfaces/pthread_attr_destroy/1-1.c
@@ -25,7 +25,7 @@
 #include "posixtest.h"
 
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	
 	pthread_exit(0);

--- a/conformance/interfaces/pthread_attr_init/2-1.c
+++ b/conformance/interfaces/pthread_attr_init/2-1.c
@@ -33,7 +33,7 @@
 
 int sem1;		/* Manual semaphore */
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	
 	/* Indicate to main() that the thread was created. */

--- a/conformance/interfaces/pthread_attr_setdetachstate/2-1.c
+++ b/conformance/interfaces/pthread_attr_setdetachstate/2-1.c
@@ -25,7 +25,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	
 	pthread_exit(0);

--- a/conformance/interfaces/pthread_attr_setinheritsched/2-1.c
+++ b/conformance/interfaces/pthread_attr_setinheritsched/2-1.c
@@ -30,7 +30,7 @@
 #define ERROR_PREFIX "unexpected error: " FUNCTION " " TEST ": "
 
 const long int policy = SCHED_FIFO;
-void *thread_func()
+void *thread_func(void* arg)
 {
 	int rc;
 	int new_policy;

--- a/conformance/interfaces/pthread_attr_setschedparam/1-1.c
+++ b/conformance/interfaces/pthread_attr_setschedparam/1-1.c
@@ -27,7 +27,7 @@
 
 volatile int thread_created = 0;
 
-void *thread_func()
+void *thread_func(void* arg)
 {
 	thread_created = 1;
 	pthread_exit(0);

--- a/conformance/interfaces/pthread_attr_setschedparam/1-2.c
+++ b/conformance/interfaces/pthread_attr_setschedparam/1-2.c
@@ -28,7 +28,7 @@
 
 volatile int thread_created = 0;
 
-void *thread_func()
+void *thread_func(void* arg)
 {
 	thread_created = 1;
 	pthread_exit(0);

--- a/conformance/interfaces/pthread_attr_setschedpolicy/1-1.c
+++ b/conformance/interfaces/pthread_attr_setschedpolicy/1-1.c
@@ -15,7 +15,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-void *thread_func()
+void *thread_func(void* arg)
 {
 	pthread_exit(0);
 	return (void*)(0);

--- a/conformance/interfaces/pthread_attr_setscope/1-1.c
+++ b/conformance/interfaces/pthread_attr_setscope/1-1.c
@@ -27,7 +27,7 @@
 
 #define CONSCOPE PTHREAD_SCOPE_SYSTEM
 
-void *thread_func()
+void *thread_func(void* arg)
 {
 	pthread_exit(0);
 	return NULL;

--- a/conformance/interfaces/pthread_attr_setstack/1-1.c
+++ b/conformance/interfaces/pthread_attr_setstack/1-1.c
@@ -32,7 +32,7 @@
 static void *stack_addr;
 size_t stack_size;
 
-void *thread_func()
+void *thread_func(void* arg)
 {
 	pthread_exit(0);
 	return NULL;

--- a/conformance/interfaces/pthread_attr_setstack/4-1.c
+++ b/conformance/interfaces/pthread_attr_setstack/4-1.c
@@ -37,7 +37,7 @@ size_t stack_size;
 int teststack() {
 	return 0;
 }
-void *thread_func()
+void *thread_func(void* arg)
 {
 	/* execute a function to test the read/right of the stack*/
 	if (teststack() != 0) {

--- a/conformance/interfaces/pthread_attr_setstacksize/1-1.c
+++ b/conformance/interfaces/pthread_attr_setstacksize/1-1.c
@@ -29,7 +29,7 @@
 
 #define STACKADDROFFSET 0x8000000
 
-void *thread_func()
+void *thread_func(void* arg)
 {
 	pthread_exit(0);
 	return NULL;

--- a/conformance/interfaces/pthread_cancel/1-1.c
+++ b/conformance/interfaces/pthread_cancel/1-1.c
@@ -45,7 +45,7 @@ void a_cleanup_func(void *unused)
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);

--- a/conformance/interfaces/pthread_cancel/1-2.c
+++ b/conformance/interfaces/pthread_cancel/1-2.c
@@ -46,7 +46,7 @@ void a_cleanup_func(void *unused)
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 

--- a/conformance/interfaces/pthread_cancel/1-3.c
+++ b/conformance/interfaces/pthread_cancel/1-3.c
@@ -53,7 +53,7 @@ void a_cleanup_func(void *unused)
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);

--- a/conformance/interfaces/pthread_cancel/2-1.c
+++ b/conformance/interfaces/pthread_cancel/2-1.c
@@ -40,7 +40,7 @@ void a_cleanup_func(void *unused)
  * loop, never reaching the cleanup_pop function.  So the only way the cleanup
  * function can be called is when the thread is canceled and all the cleanup
  * functions are supposed to be popped. */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* To enable thread immediate cancelation, since the default
 	 * is PTHREAD_CANCEL_DEFERRED. */

--- a/conformance/interfaces/pthread_cancel/3-1.c
+++ b/conformance/interfaces/pthread_cancel/3-1.c
@@ -60,7 +60,7 @@ void a_cleanup_func(void *unused)
  * function can be called is when the thread is canceled and all the cleanup
  * functions are supposed to be popped. 
  */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	int rc = 0;
 

--- a/conformance/interfaces/pthread_cancel/4-1.c
+++ b/conformance/interfaces/pthread_cancel/4-1.c
@@ -21,7 +21,7 @@
 #include "posixtest.h"
 
 int sem; 		/* Manual semaphore */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 	

--- a/conformance/interfaces/pthread_cancel/5-1.c
+++ b/conformance/interfaces/pthread_cancel/5-1.c
@@ -24,7 +24,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_exit(0);
 	return NULL;

--- a/conformance/interfaces/pthread_cleanup_pop/1-1.c
+++ b/conformance/interfaces/pthread_cleanup_pop/1-1.c
@@ -41,7 +41,7 @@ void a_cleanup_func(void *flag_val)
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_cleanup_push(a_cleanup_func, (void*) CLEANUP_CALLED);
 	pthread_cleanup_pop(1);

--- a/conformance/interfaces/pthread_cleanup_pop/1-2.c
+++ b/conformance/interfaces/pthread_cleanup_pop/1-2.c
@@ -41,7 +41,7 @@ void a_cleanup_func(void *flag_val)
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_cleanup_push(a_cleanup_func, (void*) CLEANUP_CALLED);
 	pthread_cleanup_pop(0);

--- a/conformance/interfaces/pthread_cleanup_pop/1-3.c
+++ b/conformance/interfaces/pthread_cleanup_pop/1-3.c
@@ -53,7 +53,7 @@ void a_cleanup_func3(void *flag_val)
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_cleanup_push(a_cleanup_func1, NULL);
 	pthread_cleanup_push(a_cleanup_func2, NULL);

--- a/conformance/interfaces/pthread_cleanup_push/1-1.c
+++ b/conformance/interfaces/pthread_cleanup_push/1-1.c
@@ -44,7 +44,7 @@ void a_cleanup_func(void *flag_val)
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_cleanup_push(a_cleanup_func, (void*) CLEANUP_CALLED);
 	

--- a/conformance/interfaces/pthread_cleanup_push/1-2.c
+++ b/conformance/interfaces/pthread_cleanup_push/1-2.c
@@ -48,7 +48,7 @@ void a_cleanup_func(void *flag_val)
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);

--- a/conformance/interfaces/pthread_cleanup_push/1-3.c
+++ b/conformance/interfaces/pthread_cleanup_push/1-3.c
@@ -43,7 +43,7 @@ void a_cleanup_func(void *flag_val)
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_cleanup_push(a_cleanup_func, (void*) CLEANUP_CALLED);
 	pthread_cleanup_pop(1);

--- a/conformance/interfaces/pthread_create/1-1.c
+++ b/conformance/interfaces/pthread_create/1-1.c
@@ -18,7 +18,7 @@
 #include <stdio.h>
 #include "posixtest.h"
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	
 	pthread_exit(0);

--- a/conformance/interfaces/pthread_create/1-2.c
+++ b/conformance/interfaces/pthread_create/1-2.c
@@ -21,7 +21,7 @@
 #include <unistd.h>
 #include "posixtest.h"
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	sleep(10);
 

--- a/conformance/interfaces/pthread_create/1-3.c
+++ b/conformance/interfaces/pthread_create/1-3.c
@@ -26,8 +26,8 @@
 #include <signal.h>
 #include "posixtest.h"
 
-void *a_thread_function();
-void alarm_handler();
+void *a_thread_function(void* arg);
+void alarm_handler(int);
 
 pthread_t a;
 
@@ -62,7 +62,7 @@ int main()
 }
 
 /* A never-ending thread function */
-void *a_thread_function()
+void *a_thread_function(void* arg)
 {
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 	
@@ -74,7 +74,7 @@ void *a_thread_function()
 }
 
 /* If this handler is called, that means that the test has failed. */
-void alarm_handler()
+void alarm_handler(int unused)
 {
 	printf("Test FAILED\n");
 	exit(PTS_FAIL);

--- a/conformance/interfaces/pthread_create/12-1.c
+++ b/conformance/interfaces/pthread_create/12-1.c
@@ -20,7 +20,7 @@
 #include "posixtest.h"
 
 /* Thread starting routine that really does nothing. */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_exit(0);
 	return NULL;

--- a/conformance/interfaces/pthread_create/2-1.c
+++ b/conformance/interfaces/pthread_create/2-1.c
@@ -25,7 +25,7 @@
 #include <errno.h>
 #include "posixtest.h"
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	
 	pthread_exit(0);

--- a/conformance/interfaces/pthread_create/3-1.c
+++ b/conformance/interfaces/pthread_create/3-1.c
@@ -32,7 +32,7 @@
 
 int sem1;		/* Manual semaphore */
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Indicate to main() that the thread was created. */
 	sem1=INTHREAD;

--- a/conformance/interfaces/pthread_create/4-1.c
+++ b/conformance/interfaces/pthread_create/4-1.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include "posixtest.h"
 
-void *a_thread_func();
+void *a_thread_func(void* arg);
 
 pthread_t self_th; 	/* Save the value of the function call pthread_self() 
 			   within the thread.  Keeping it global so 'main' can 
@@ -59,7 +59,7 @@ int main()
 }
 
 /* The thread function that calls pthread_self() to obtain its thread ID */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	self_th=pthread_self();
 	pthread_exit(0);

--- a/conformance/interfaces/pthread_detach/1-1.c
+++ b/conformance/interfaces/pthread_detach/1-1.c
@@ -26,7 +26,7 @@
 #include "posixtest.h"
 
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
 

--- a/conformance/interfaces/pthread_detach/2-1.c
+++ b/conformance/interfaces/pthread_detach/2-1.c
@@ -24,7 +24,7 @@
 #include "posixtest.h"
 
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);

--- a/conformance/interfaces/pthread_detach/3-1.c
+++ b/conformance/interfaces/pthread_detach/3-1.c
@@ -23,7 +23,7 @@
 #include "posixtest.h"
 
 /* Thread function */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);

--- a/conformance/interfaces/pthread_detach/4-1.c
+++ b/conformance/interfaces/pthread_detach/4-1.c
@@ -28,7 +28,7 @@
 #include "posixtest.h"
 
 /* Thread function */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);

--- a/conformance/interfaces/pthread_detach/4-2.c
+++ b/conformance/interfaces/pthread_detach/4-2.c
@@ -29,7 +29,7 @@
 #include "posixtest.h"
 
 /* Thread function */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {	
 	pthread_exit(0);
 	return NULL;

--- a/conformance/interfaces/pthread_equal/1-1.c
+++ b/conformance/interfaces/pthread_equal/1-1.c
@@ -22,7 +22,7 @@
 #include "posixtest.h"
 
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	
 	pthread_exit(0);

--- a/conformance/interfaces/pthread_equal/1-2.c
+++ b/conformance/interfaces/pthread_equal/1-2.c
@@ -22,7 +22,7 @@
 #include "posixtest.h"
 
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	
 	pthread_exit(0);

--- a/conformance/interfaces/pthread_exit/1-1.c
+++ b/conformance/interfaces/pthread_exit/1-1.c
@@ -31,7 +31,7 @@
 int sem;	/* Manual semaphore used to indicate when the thread has been created. */
 
 /* Thread's function. */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	sem=INMAIN;
 	pthread_exit((void*)RETURN_CODE);

--- a/conformance/interfaces/pthread_exit/2-1.c
+++ b/conformance/interfaces/pthread_exit/2-1.c
@@ -54,7 +54,7 @@ void a_cleanup_func3(void *dummy)
 	return;
 }
 /* Thread's function. */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Set up 3 cleanup handlers */
 	pthread_cleanup_push(a_cleanup_func1,NULL);

--- a/conformance/interfaces/pthread_getschedparam/1-1.c
+++ b/conformance/interfaces/pthread_getschedparam/1-1.c
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 #include "posixtest.h"
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	struct sched_param sparam;
 	int policy;

--- a/conformance/interfaces/pthread_getschedparam/1-2.c
+++ b/conformance/interfaces/pthread_getschedparam/1-2.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include "posixtest.h"
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	struct sched_param sparam;
 	int policy, priority, policy_1;

--- a/conformance/interfaces/pthread_join/1-1.c
+++ b/conformance/interfaces/pthread_join/1-1.c
@@ -24,7 +24,7 @@
 int end_exec;	/* Global flag indicating the the thread function has finished execution. */
 
 /* Thread's function. */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	int i;
 	

--- a/conformance/interfaces/pthread_join/2-1.c
+++ b/conformance/interfaces/pthread_join/2-1.c
@@ -32,7 +32,7 @@
 int sem;	/* Manual semaphore used to indicate when the thread has been created. */
 
 /* Thread's function. */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	sem=INMAIN;
 	pthread_exit(RETURN_CODE);

--- a/conformance/interfaces/pthread_join/3-1.c
+++ b/conformance/interfaces/pthread_join/3-1.c
@@ -38,7 +38,7 @@ void a_cleanup_func(void *unused)
 }
 
 /* Thread's function. */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);

--- a/conformance/interfaces/pthread_join/5-1.c
+++ b/conformance/interfaces/pthread_join/5-1.c
@@ -23,7 +23,7 @@
 #include "posixtest.h"
 
 /* Thread's function. */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_exit(0);
 	return NULL;

--- a/conformance/interfaces/pthread_join/6-2.c
+++ b/conformance/interfaces/pthread_join/6-2.c
@@ -36,7 +36,7 @@
 #include "posixtest.h"
 
 /* Thread's function. */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_exit(0);
 	return NULL;

--- a/conformance/interfaces/pthread_key_create/1-2.c
+++ b/conformance/interfaces/pthread_key_create/1-2.c
@@ -31,7 +31,7 @@ pthread_key_t keys[NUM_OF_THREADS];
 int i;
 
 /* Thread function that sets the key to KEY_VALUE */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Set the key to KEY_VALUE */
 	if(pthread_setspecific(keys[i], (void *)(KEY_VALUE)) != 0)

--- a/conformance/interfaces/pthread_key_create/3-1.c
+++ b/conformance/interfaces/pthread_key_create/3-1.c
@@ -38,7 +38,7 @@ void dest_func(void *p)
 }
 
 /* Thread function */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 
 	/* Set the value of the key to a value */	

--- a/conformance/interfaces/pthread_key_delete/2-1.c
+++ b/conformance/interfaces/pthread_key_delete/2-1.c
@@ -41,7 +41,7 @@ void dest_func(void *p)
 }
 
 /* Thread function */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 
 	/* Set the value of the key to a value */	

--- a/conformance/interfaces/pthread_mutexattr_settype/3-2.c
+++ b/conformance/interfaces/pthread_mutexattr_settype/3-2.c
@@ -37,7 +37,7 @@ pthread_mutexattr_t mta;
 
 int ret;			/* Return value of the thread unlocking the mutex. */
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Try to unlock the mutex that main already locked. */
 	ret=pthread_mutex_unlock(&mutex);

--- a/conformance/interfaces/pthread_once/3-1.c
+++ b/conformance/interfaces/pthread_once/3-1.c
@@ -47,7 +47,7 @@ void an_init_func()
 }
 
 /* Thread function */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Make the thread cancelable immediately */
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);

--- a/conformance/interfaces/pthread_self/1-1.c
+++ b/conformance/interfaces/pthread_self/1-1.c
@@ -26,7 +26,7 @@
 pthread_t new_th2;	/* Global thread to hold the value of when pthread_self
 			   returns from the thread function. */
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	new_th2=pthread_self();
 	pthread_exit(0);

--- a/conformance/interfaces/pthread_setcancelstate/1-1.c
+++ b/conformance/interfaces/pthread_setcancelstate/1-1.c
@@ -35,7 +35,7 @@ int sem1;		/* Manual semaphore */
 int cancel_flag;
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Set cancel state to ENABLE, meaning it should honor all cancel requests. */
 	/* Set cancel type to ASYNCHRONOUS so that it honors cancel requests immediately. */

--- a/conformance/interfaces/pthread_setcancelstate/1-2.c
+++ b/conformance/interfaces/pthread_setcancelstate/1-2.c
@@ -35,7 +35,7 @@ int sem1;		/* Manual semaphore */
 int cancel_flag;
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Set cancel state to DISABLE, meaning it shouldn't honor any cancel requests. */
 	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);

--- a/conformance/interfaces/pthread_setcancelstate/2-1.c
+++ b/conformance/interfaces/pthread_setcancelstate/2-1.c
@@ -30,7 +30,7 @@ int sem1;		/* Manual semaphore */
 int cancel_flag;
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Set default cancel state should be ENABLE, meaning it should honor all 
 	 * cancel requests. */

--- a/conformance/interfaces/pthread_setcancelstate/3-1.c
+++ b/conformance/interfaces/pthread_setcancelstate/3-1.c
@@ -28,7 +28,7 @@
 int ret; 		/* Return value of pthread_setcancelstate(). */
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Set cancel state to an invalid integer and save the return value. */
 	ret=pthread_setcancelstate(-100, NULL);

--- a/conformance/interfaces/pthread_setcanceltype/1-1.c
+++ b/conformance/interfaces/pthread_setcanceltype/1-1.c
@@ -49,7 +49,7 @@ void a_cleanup_func(void *unused)
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);

--- a/conformance/interfaces/pthread_setcanceltype/1-2.c
+++ b/conformance/interfaces/pthread_setcanceltype/1-2.c
@@ -45,14 +45,14 @@ pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;	/* Mutex */
 
 /* Cleanup function that the thread executes when it is canceled.  So if
  * cleanup_flag is 1, it means that the thread was canceled. */
-void a_cleanup_func()	
+void a_cleanup_func(void* arg)
 {
 	cleanup_flag=-1;
 	return;
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);

--- a/conformance/interfaces/pthread_setcanceltype/2-1.c
+++ b/conformance/interfaces/pthread_setcanceltype/2-1.c
@@ -41,14 +41,14 @@ pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;	/* Mutex */
 
 /* Cleanup function that the thread executes when it is canceled.  So if
  * cleanup_flag is 1, it means that the thread was canceled. */
-void a_cleanup_func()	
+void a_cleanup_func(void* arg)
 {
 	cleanup_flag=-1;
 	return;
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 	

--- a/conformance/interfaces/pthread_setschedparam/1-1.c
+++ b/conformance/interfaces/pthread_setschedparam/1-1.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include "posixtest.h"
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	struct sched_param sparam;
 	int policy, priority, policy_1;

--- a/conformance/interfaces/pthread_setschedprio/1-1.c
+++ b/conformance/interfaces/pthread_setschedprio/1-1.c
@@ -23,7 +23,7 @@
 #include <stdlib.h>
 #include "posixtest.h"
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	struct sched_param sparam;
 	int policy, priority, policy_1;

--- a/conformance/interfaces/pthread_setspecific/1-2.c
+++ b/conformance/interfaces/pthread_setspecific/1-2.c
@@ -34,7 +34,7 @@ pthread_key_t key;
 void* rc1;
 void* rc2;
 
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Bind a value to key for this thread (this will be different from the value
 	 * that we bind for the main thread) */

--- a/conformance/interfaces/pthread_spin_destroy/3-1.c
+++ b/conformance/interfaces/pthread_spin_destroy/3-1.c
@@ -48,7 +48,10 @@ static void* fn_chld(void *arg)
 		printf("child: got return code %d, %s\n", rc, strerror(rc));	
 		printf("Test PASSED: *Note: Did not return EBUSY when destroying a spinlock already in use, but standard says 'may' fail\n");
 	}
+#ifndef __EMSCRIPTEN__
 	exit(PTS_PASS);
+#endif
+	return NULL;
 }
  
 int main()

--- a/conformance/interfaces/pthread_spin_init/4-1.c
+++ b/conformance/interfaces/pthread_spin_init/4-1.c
@@ -47,7 +47,10 @@ static void* fn_chld(void* arg)
 		printf("child: got return code %d, %s\n", rc, strerror(rc));
 		printf("Test PASSED: *Note: Did not return EBUSY when initializing a spinlock already in use, but standard says 'may' fail\n");
 	}
+#ifndef __EMSCRIPTEN__
 	exit(PTS_PASS);
+#endif
+	return NULL;
 }
  
 int main()

--- a/conformance/interfaces/pthread_testcancel/1-1.c
+++ b/conformance/interfaces/pthread_testcancel/1-1.c
@@ -45,14 +45,14 @@ pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;	/* Mutex */
 
 /* Cleanup function that the thread executes when it is canceled.  So if
  * cleanup_flag is 1, it means that the thread was canceled. */
-void a_cleanup_func()	
+void a_cleanup_func(void* arg)
 {
 	cleanup_flag=-1;
 	return;
 }
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);

--- a/conformance/interfaces/pthread_testcancel/2-1.c
+++ b/conformance/interfaces/pthread_testcancel/2-1.c
@@ -31,7 +31,7 @@ int sem1;		/* Manual semaphore */
 int cancel_flag;
 
 /* Function that the thread executes upon its creation */
-void *a_thread_func()
+void *a_thread_func(void* arg)
 {
 	/* Set cancel state to DISABLE, meaning it shouldn't honor any cancel requests. */
 	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);


### PR DESCRIPTION
`pthread_create` function requires that start_routine has `void*(void*)` signature. However many tests defined this function as `void*(void)`. When compiling such test to native code such pointer was implicitly casted. In case of Emscripten such casts are won't work and resulted in exception thrown at JavaScript side.

This PR adjust tests start_routine to have proper signature.