### PR TITLE
Emscripten now handles exit() in pthreads

### DIFF
--- a/conformance/interfaces/pthread_cond_timedwait/4-1.c
+++ b/conformance/interfaces/pthread_cond_timedwait/4-1.c
@@ -52,12 +52,12 @@ void *t1_func(void *arg)
 	if (rc == ETIMEDOUT) {
 		fprintf(stderr,"Thread1 stops waiting when time is out\n");
 		printf("Test PASSED\n");
-		pthread_exit(PTS_PASS);
+		exit(PTS_PASS);
 	}
 	else {
 		fprintf(stderr,"pthread_cond_timedwait return %d instead of ETIMEDOUT\n", rc);
                 printf("Test FAILED\n");
-		pthread_exit(PTS_FAIL);
+		exit(PTS_FAIL);
         }
 }
 


### PR DESCRIPTION
This PR reverts a Emscripten specific change to the Open POSIX Test Suite. Since PR https://github.com/emscripten-core/emscripten/pull/12933 (Emscripten v2.0.10) commit https://github.com/juj/posixtestsuite/commit/e350af1fd4be3e5185d0b3efac3c96531a2ba592 can be safely reverted as `exit()` calls are now being proxied back to the main thread.

/cc @sbc100 as he is the author of https://github.com/emscripten-core/emscripten/pull/12933.