### PR TITLE
Move skipped test cases to Emscripten

### DIFF
--- a/conformance/interfaces/pthread_atfork/1-1.c
+++ b/conformance/interfaces/pthread_atfork/1-1.c
@@ -58,10 +58,6 @@ static void child_handler()
 
 int main ()
 {
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: multiple processes and fork() is not supported in Emscripten.\n");
-	exit(0);
-#endif
 	pid_t pid;
 
 	/* Initialize values */

--- a/conformance/interfaces/pthread_atfork/1-2.c
+++ b/conformance/interfaces/pthread_atfork/1-2.c
@@ -191,11 +191,6 @@ int main( int argc, char * argv[] )
 {
 	int ret;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: multiple processes and fork() is not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Initialize output */
 	output_init();
 

--- a/conformance/interfaces/pthread_atfork/2-1.c
+++ b/conformance/interfaces/pthread_atfork/2-1.c
@@ -31,11 +31,6 @@ int main ()
 	pid_t pid;
 	int ret;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: multiple processes and fork() is not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Set up the fork handlers */
 	ret = pthread_atfork(NULL, NULL, NULL);
 	if(ret != 0)

--- a/conformance/interfaces/pthread_atfork/2-2.c
+++ b/conformance/interfaces/pthread_atfork/2-2.c
@@ -219,11 +219,6 @@ int main( int argc, char * argv[] )
 	int ret;
 	pthread_t ch;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: multiple processes and fork() is not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Initialize output */
 	output_init();
 

--- a/conformance/interfaces/pthread_atfork/3-2.c
+++ b/conformance/interfaces/pthread_atfork/3-2.c
@@ -180,11 +180,6 @@ int main( int argc, char * argv[] )
 	int ret, i;
 	pthread_t ch;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: multiple processes and fork() is not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Initialize output */
 	output_init();
 

--- a/conformance/interfaces/pthread_atfork/4-1.c
+++ b/conformance/interfaces/pthread_atfork/4-1.c
@@ -219,11 +219,6 @@ int main( int argc, char * argv[] )
 	int ret;
 	pthread_t ch;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: multiple processes and fork() is not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Initialize output */
 	output_init();
 

--- a/conformance/interfaces/pthread_barrier_wait/3-1.c
+++ b/conformance/interfaces/pthread_barrier_wait/3-1.c
@@ -83,11 +83,6 @@ int main()
 	pthread_t child_thread;
 	sig_rcvd = 0;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	printf("Initialize barrier with count = 2\n");
 	if(pthread_barrier_init(&barrier, NULL, 2) != 0)
 	{

--- a/conformance/interfaces/pthread_barrier_wait/3-2.c
+++ b/conformance/interfaces/pthread_barrier_wait/3-2.c
@@ -90,11 +90,6 @@ int main()
 	pthread_t child_thread;
 	sig_rcvd = 0;
 	barrier_waited = 0;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
 	
 	printf("Initialize barrier with count = 2\n");
 	if(pthread_barrier_init(&barrier, NULL, 2) != 0)

--- a/conformance/interfaces/pthread_barrierattr_getpshared/2-1.c
+++ b/conformance/interfaces/pthread_barrierattr_getpshared/2-1.c
@@ -62,11 +62,6 @@ int main()
 	pthread_barrierattr_t ba;
 	int	pshared = PTHREAD_PROCESS_SHARED;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support shm_open and shm_unlink.\n");
-	exit(0);
-#endif
-
 	char 	shm_name[] = "tmp_pthread_barrierattr_getpshared";
 	int 	shm_fd;
 	int 	pid;

--- a/conformance/interfaces/pthread_cancel/5-2.c
+++ b/conformance/interfaces/pthread_cancel/5-2.c
@@ -239,11 +239,6 @@ int main ( int argc, char * argv[] )
 
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-       printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-       exit(0);
-#endif
-
 	/* Initialize output routine */
 	output_init();
 

--- a/conformance/interfaces/pthread_cond_broadcast/1-2.c
+++ b/conformance/interfaces/pthread_cond_broadcast/1-2.c
@@ -297,11 +297,6 @@ int main (int argc, char * argv[])
 	
 	testdata_t alternativ;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
-
 	output_init();
 	
 	/* check the system abilities */

--- a/conformance/interfaces/pthread_cond_broadcast/2-3.c
+++ b/conformance/interfaces/pthread_cond_broadcast/2-3.c
@@ -287,11 +287,6 @@ int main (int argc, char * argv[])
 	pthread_attr_t ta;
 	
 	testdata_t alternativ;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
 	
 	output_init();
 	

--- a/conformance/interfaces/pthread_cond_broadcast/4-2.c
+++ b/conformance/interfaces/pthread_cond_broadcast/4-2.c
@@ -211,10 +211,6 @@ int main (int argc, char * argv[])
 	thestruct arg1, arg2;
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
 	output_init();
 	
 	/* We need to register the signal handlers for the PROCESS */

--- a/conformance/interfaces/pthread_cond_destroy/2-1.c
+++ b/conformance/interfaces/pthread_cond_destroy/2-1.c
@@ -298,11 +298,6 @@ int main (int argc, char * argv[])
 	pthread_t t_timer;
 	
 	testdata_t alternativ;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
 	
 	output_init();
 	

--- a/conformance/interfaces/pthread_cond_init/1-2.c
+++ b/conformance/interfaces/pthread_cond_init/1-2.c
@@ -177,11 +177,6 @@ int do_cs_test(void)
 	struct timespec diff;
 	char sens=0;
 	
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: clock_settime() is not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* We are going to initialize the cond vars and the mutexes */
 	dtN.pmtx = &mtxN;
 	dtD.pmtx = &mtxD;

--- a/conformance/interfaces/pthread_cond_init/1-3.c
+++ b/conformance/interfaces/pthread_cond_init/1-3.c
@@ -853,11 +853,6 @@ int main(int argc, char * argv[])
 	long opt_TPS, opt_MF;
 	int ret=0;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
-
 	output_init();
 	
 	#if VERBOSE > 1

--- a/conformance/interfaces/pthread_cond_init/2-2.c
+++ b/conformance/interfaces/pthread_cond_init/2-2.c
@@ -609,11 +609,6 @@ int main(int argc, char * argv[])
 	long opt_TMR, opt_CS;
 	int ret=0;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: clock_settime() is not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	output_init();
 	
 	#if VERBOSE > 1

--- a/conformance/interfaces/pthread_cond_init/4-1.c
+++ b/conformance/interfaces/pthread_cond_init/4-1.c
@@ -106,10 +106,6 @@ int main(int argc, char * argv[])
 	
 	int status=0;
 	
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: multiple processes and fork() is not supported in Emscripten.\n");
-	exit(0);
-#endif
 
 	output_init();
 

--- a/conformance/interfaces/pthread_cond_init/4-2.c
+++ b/conformance/interfaces/pthread_cond_init/4-2.c
@@ -238,11 +238,6 @@ int main (int argc, char * argv[])
 	pthread_t th_work, th_sig1, th_sig2;
 	thestruct arg1, arg2;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	output_init();
 
 	#ifdef WITH_SYNCHRO

--- a/conformance/interfaces/pthread_cond_signal/1-2.c
+++ b/conformance/interfaces/pthread_cond_signal/1-2.c
@@ -262,11 +262,6 @@ int main (int argc, char * argv[])
 	
 	testdata_t alternativ;
 	
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
-
 	output_init();
 	
 	/* check the system abilities */

--- a/conformance/interfaces/pthread_cond_signal/4-2.c
+++ b/conformance/interfaces/pthread_cond_signal/4-2.c
@@ -212,11 +212,6 @@ int main (int argc, char * argv[])
 	thestruct arg1, arg2;
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	output_init();
 	
 	/* We need to register the signal handlers for the PROCESS */

--- a/conformance/interfaces/pthread_cond_timedwait/2-4.c
+++ b/conformance/interfaces/pthread_cond_timedwait/2-4.c
@@ -261,11 +261,6 @@ int main(int argc, char * argv[])
 	pthread_t child_th;
 	
 	long pshared, monotonic, cs, mf;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
 	
 	output_init();
 	pshared = sysconf(_SC_THREAD_PROCESS_SHARED);

--- a/conformance/interfaces/pthread_cond_timedwait/2-7.c
+++ b/conformance/interfaces/pthread_cond_timedwait/2-7.c
@@ -267,11 +267,6 @@ int main(int argc, char * argv[])
 	pthread_t child_th;
 	
 	long pshared, monotonic, cs, mf;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
 	
 	output_init();
 	pshared = sysconf(_SC_THREAD_PROCESS_SHARED);

--- a/conformance/interfaces/pthread_cond_timedwait/4-2.c
+++ b/conformance/interfaces/pthread_cond_timedwait/4-2.c
@@ -210,11 +210,6 @@ int main(int argc, char * argv[])
 	pthread_t child_th[NCHILDREN];
 	
 	long pshared, monotonic, cs, mf;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
 	
 	output_init();
 	pshared = sysconf(_SC_THREAD_PROCESS_SHARED);

--- a/conformance/interfaces/pthread_cond_wait/2-2.c
+++ b/conformance/interfaces/pthread_cond_wait/2-2.c
@@ -246,11 +246,6 @@ int main(int argc, char * argv[])
 	pthread_t child_th;
 	
 	long pshared, monotonic, cs, mf;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
 	
 	output_init();
 	pshared = sysconf(_SC_THREAD_PROCESS_SHARED);

--- a/conformance/interfaces/pthread_cond_wait/4-1.c
+++ b/conformance/interfaces/pthread_cond_wait/4-1.c
@@ -235,11 +235,6 @@ int main (int argc, char * argv[])
 	thestruct arg1, arg2;
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	output_init();
 	
 	/* We need to register the signal handlers for the PROCESS */

--- a/conformance/interfaces/pthread_create/1-4.c
+++ b/conformance/interfaces/pthread_create/1-4.c
@@ -156,11 +156,6 @@ int main (int argc, char *argv[])
 	pthread_t child;
 	int i;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: semaphores are not currently supported (TODO).\n");
-	exit(0);
-#endif
-
 	output_init();
 	
 	td.tid=pthread_self();

--- a/conformance/interfaces/pthread_create/1-5.c
+++ b/conformance/interfaces/pthread_create/1-5.c
@@ -91,15 +91,7 @@
 /********************************************************************************************/
 /***********************************    Test cases  *****************************************/
 /********************************************************************************************/
-#ifdef __EMSCRIPTEN__
-int main()
-{
-  printf("Test SKIPPED: semaphores are not currently supported (TODO).\n");
-  exit(0);
-}
-#else
 #define STD_MAIN /* This allows main() to be defined in the included file */
-#endif
 #include "threads_scenarii.c"
 
 /* This file will define the following objects:

--- a/conformance/interfaces/pthread_create/1-6.c
+++ b/conformance/interfaces/pthread_create/1-6.c
@@ -85,15 +85,7 @@
 /********************************************************************************************/
 /***********************************    Test cases  *****************************************/
 /********************************************************************************************/
-#ifdef __EMSCRIPTEN__
-int main()
-{
-  printf("Test SKIPPED: semaphores are not currently supported (TODO).\n");
-  exit(0);
-}
-#else
 #define STD_MAIN /* This allows main() to be defined in the included file */
-#endif
 
 #include "threads_scenarii.c"
 

--- a/conformance/interfaces/pthread_create/10-1.c
+++ b/conformance/interfaces/pthread_create/10-1.c
@@ -97,11 +97,6 @@ int main()
 	pthread_attr_t inv_attr;
 	struct sigaction act;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Inializing flags. */
 	segfault_flag = 1;
 	created_thread = 0;

--- a/conformance/interfaces/pthread_create/14-1.c
+++ b/conformance/interfaces/pthread_create/14-1.c
@@ -255,11 +255,6 @@ int main (int argc, char * argv[])
 	pthread_t th_work, th_sig1, th_sig2;
 	thestruct arg1, arg2;
 	struct sigaction sa;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
 	
 	/* Initialize output routine */
 	output_init();

--- a/conformance/interfaces/pthread_create/15-1.c
+++ b/conformance/interfaces/pthread_create/15-1.c
@@ -86,15 +86,7 @@
 /***********************************    Test cases  *****************************************/
 /********************************************************************************************/
 
-#ifdef __EMSCRIPTEN__
-int main()
-{
-  printf("Test SKIPPED: semaphores are not currently supported (TODO).\n");
-  exit(0);
-}
-#else
 #define STD_MAIN
-#endif
 #include "threads_scenarii.c"
 
 /* This file will define the following objects:

--- a/conformance/interfaces/pthread_create/8-1.c
+++ b/conformance/interfaces/pthread_create/8-1.c
@@ -49,11 +49,6 @@ int main()
 	sigset_t main_sigmask, main_pendingset;
 	int ret;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Empty set of signal mask and blocked signals */
 	if ( (sigemptyset(&main_sigmask) != 0) || 
 		(sigemptyset(&main_pendingset) != 0) )

--- a/conformance/interfaces/pthread_create/8-2.c
+++ b/conformance/interfaces/pthread_create/8-2.c
@@ -140,11 +140,6 @@ int main (int argc, char *argv[])
 	
 	testdata_t td_parent, td_thread;
 	
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Initialize output routine */
 	output_init();
 	

--- a/conformance/interfaces/pthread_detach/1-2.c
+++ b/conformance/interfaces/pthread_detach/1-2.c
@@ -123,11 +123,6 @@ int main (int argc, char *argv[])
 	int ret=0;
 	pthread_t child;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: semaphores are not currently supported (TODO).\n");
-	exit(0);
-#endif
-
 	output_init();
 	
 	scenar_init();

--- a/conformance/interfaces/pthread_detach/4-3.c
+++ b/conformance/interfaces/pthread_detach/4-3.c
@@ -252,10 +252,6 @@ int main (int argc, char * argv[])
 	thestruct arg1, arg2;
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
 	/* Initialize output routine */
 	output_init();
 	

--- a/conformance/interfaces/pthread_equal/2-1.c
+++ b/conformance/interfaces/pthread_equal/2-1.c
@@ -178,10 +178,6 @@ int main (int argc, char * argv[])
 	thestruct arg1, arg2;
 	struct sigaction sa;
 	
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
 	/* Initialize output routine */
 	output_init();
 	

--- a/conformance/interfaces/pthread_exit/6-1.c
+++ b/conformance/interfaces/pthread_exit/6-1.c
@@ -194,11 +194,6 @@ int main (int argc, char *argv[])
 	pthread_t child;
 	
 	mf =sysconf(_SC_MAPPED_FILES);
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
 	
 	output_init();
 	

--- a/conformance/interfaces/pthread_exit/6-2.c
+++ b/conformance/interfaces/pthread_exit/6-2.c
@@ -85,17 +85,7 @@
 /********************************************************************************************/
 
 /* main is defined in the next file */
-#ifdef __EMSCRIPTEN__
-int main()
-{
-#ifdef __EMSCRIPTEN__
-  printf("Test SKIPPED: semaphores are not currently supported (TODO).\n");
-  exit(0);
-#endif
-}
-#else
 #define STD_MAIN
-#endif
 #include "threads_scenarii.c"
 
 /* This file will define the following objects:

--- a/conformance/interfaces/pthread_getschedparam/4-1.c
+++ b/conformance/interfaces/pthread_getschedparam/4-1.c
@@ -214,11 +214,6 @@ int main ( int argc, char * argv[] )
 
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Initialize output routine */
 	output_init();
 

--- a/conformance/interfaces/pthread_join/6-3.c
+++ b/conformance/interfaces/pthread_join/6-3.c
@@ -254,10 +254,6 @@ int main ( int argc, char * argv[] )
 
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
 	/* Initialize output routine */
 	output_init();
 

--- a/conformance/interfaces/pthread_kill/1-1.c
+++ b/conformance/interfaces/pthread_kill/1-1.c
@@ -79,10 +79,6 @@ int main()
 {
 	pthread_t new_th;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
 	sem1=INTHREAD;
 
 	if(pthread_create(&new_th, NULL, a_thread_func, NULL) != 0)

--- a/conformance/interfaces/pthread_kill/1-2.c
+++ b/conformance/interfaces/pthread_kill/1-2.c
@@ -118,10 +118,6 @@ int main( int argc, char * argv[] )
 
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
 	/* Initialize output */
 	output_init();
 

--- a/conformance/interfaces/pthread_kill/8-1.c
+++ b/conformance/interfaces/pthread_kill/8-1.c
@@ -232,10 +232,6 @@ int main ( int argc, char * argv[] )
 
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
 	/* Initialize output routine */
 	output_init();
 

--- a/conformance/interfaces/pthread_mutex_getprioceiling/1-1.c
+++ b/conformance/interfaces/pthread_mutex_getprioceiling/1-1.c
@@ -33,11 +33,6 @@ int main()
 	pthread_mutex_t mutex;
 	int prioceiling, max_prio, min_prio;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support pthread_mutex_getprioceiling.\n");
-	exit(0);
-#endif
-
 	/* Initialize a mutex object */
 	if(pthread_mutex_init(&mutex, NULL) != 0)
 	{

--- a/conformance/interfaces/pthread_mutex_init/1-2.c
+++ b/conformance/interfaces/pthread_mutex_init/1-2.c
@@ -173,11 +173,6 @@ int main(int argc, char *argv[])
 	void * th_ret;
 	
 	int i;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: semaphores are not currently supported (TODO).\n");
-	exit(0);
-#endif
 	
 	output_init();
 	

--- a/conformance/interfaces/pthread_mutex_init/3-2.c
+++ b/conformance/interfaces/pthread_mutex_init/3-2.c
@@ -178,11 +178,6 @@ int main(int argc, char *argv[])
 	void * th_ret;
 	
 	int i;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: semaphores are not currently supported (TODO).\n");
-	exit(0);
-#endif
 	
 	output_init();
 	#if VERBOSE >1

--- a/conformance/interfaces/pthread_mutex_init/5-1.c
+++ b/conformance/interfaces/pthread_mutex_init/5-1.c
@@ -106,10 +106,6 @@ int main(int argc, char * argv[])
 	
 	int status=0;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: multiple processes and fork() is not supported in Emscripten.\n");
-	exit(0);
-#endif
 	output_init();
 
 	child = fork();

--- a/conformance/interfaces/pthread_mutex_lock/3-1.c
+++ b/conformance/interfaces/pthread_mutex_lock/3-1.c
@@ -290,11 +290,6 @@ int main (int argc, char * argv[])
 	
 	output_init();
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	#ifdef WITH_SYNCHRO
 	#if VERBOSE >1
 	output("Running in synchronized mode\n");

--- a/conformance/interfaces/pthread_mutex_lock/4-1.c
+++ b/conformance/interfaces/pthread_mutex_lock/4-1.c
@@ -145,11 +145,6 @@ int main(int argc, char * argv[])
 
 	output_init();
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: semaphores are not currently supported (TODO).\n");
-	exit(0);
-#endif
-
 	#if VERBOSE >1
 	output("Initialize the PTHREAD_MUTEX_RECURSIVE mutex\n");
 	#endif

--- a/conformance/interfaces/pthread_mutex_lock/5-1.c
+++ b/conformance/interfaces/pthread_mutex_lock/5-1.c
@@ -146,11 +146,6 @@ int main (int argc, char * argv[])
 	pthread_mutexattr_t ma[4], *pma[5];
 	pma[4]=NULL;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	output_init();
 
 	/* Initialize the mutex attributes */	

--- a/conformance/interfaces/pthread_mutex_trylock/1-2.c
+++ b/conformance/interfaces/pthread_mutex_trylock/1-2.c
@@ -158,11 +158,6 @@ int main(int argc, char * argv[])
 	pthread_t child_th;
 	
 	long pshared, mf;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
 	
 	/* Initialize output */
 	output_init();

--- a/conformance/interfaces/pthread_mutex_trylock/2-1.c
+++ b/conformance/interfaces/pthread_mutex_trylock/2-1.c
@@ -146,11 +146,6 @@ int main(int argc, char * argv[])
 	pthread_t child_th;
 	
 	long pshared, mf;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
 	
 	/* Initialize output */
 	output_init();

--- a/conformance/interfaces/pthread_mutex_trylock/4-2.c
+++ b/conformance/interfaces/pthread_mutex_trylock/4-2.c
@@ -156,11 +156,6 @@ int main(int argc, char * argv[])
 	pthread_t child_th;
 	
 	long pshared, mf;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: lacking necessary mmap() support in Emscripten.\n");
-	exit(0);
-#endif
 	
 	/* Initialize output */
 	output_init();

--- a/conformance/interfaces/pthread_mutex_trylock/4-3.c
+++ b/conformance/interfaces/pthread_mutex_trylock/4-3.c
@@ -268,11 +268,6 @@ int main (int argc, char * argv[])
 	thestruct arg1, arg2;
 	struct sigaction sa;
 	
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Initialize output routine */
 	output_init();
 	

--- a/conformance/interfaces/pthread_mutexattr_getprioceiling/1-2.c
+++ b/conformance/interfaces/pthread_mutexattr_getprioceiling/1-2.c
@@ -36,11 +36,6 @@ int main()
 	pthread_mutexattr_t mta;
 	int prioceiling, max_prio, min_prio, i;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support pthread_mutexattr_setprioceiling.\n");
-	exit(0);
-#endif
-
 	/* Initialize a mutex attributes object */
 	if(pthread_mutexattr_init(&mta) != 0)
 	{

--- a/conformance/interfaces/pthread_mutexattr_getprotocol/1-2.c
+++ b/conformance/interfaces/pthread_mutexattr_getprotocol/1-2.c
@@ -23,11 +23,6 @@ int main()
 	
 	pthread_mutexattr_t mta;
 	int protocol, protcls[3],i;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support pthread_mutexattr_setprotocol to a nonzero value.\n");
-	exit(0);
-#endif
 	
 	/* Initialize a mutex attributes object */
 	if(pthread_mutexattr_init(&mta) != 0)

--- a/conformance/interfaces/pthread_mutexattr_setprioceiling/1-1.c
+++ b/conformance/interfaces/pthread_mutexattr_setprioceiling/1-1.c
@@ -35,11 +35,6 @@ int main()
 	pthread_mutexattr_t mta;
 	int max_prio, min_prio, i;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support pthread_mutexattr_setprioceiling.\n");
-	exit(0);
-#endif
-
 	/* Initialize a mutex attributes object */
 	if(pthread_mutexattr_init(&mta) != 0)
 	{

--- a/conformance/interfaces/pthread_mutexattr_setprioceiling/3-1.c
+++ b/conformance/interfaces/pthread_mutexattr_setprioceiling/3-1.c
@@ -37,11 +37,6 @@ int main()
 	pthread_mutexattr_t mta;
 	int prioceiling, ret;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support pthread_mutexattr_setprioceiling.\n");
-	exit(0);
-#endif
-
 	prioceiling = sched_get_priority_min(SCHED_FIFO);
 	
 	/* Set the prioceiling of an unintialized mutex attr. */

--- a/conformance/interfaces/pthread_mutexattr_setprioceiling/3-2.c
+++ b/conformance/interfaces/pthread_mutexattr_setprioceiling/3-2.c
@@ -37,11 +37,6 @@ int main()
 	pthread_mutexattr_t mta;
 	int prioceiling, ret;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support pthread_mutexattr_setprioceiling.\n");
-	exit(0);
-#endif
-
 	/* Set 'prioceiling' out of SCHED_FIFO boundry. */
 	prioceiling = sched_get_priority_max(SCHED_FIFO);
 	prioceiling++;

--- a/conformance/interfaces/pthread_mutexattr_setprotocol/1-1.c
+++ b/conformance/interfaces/pthread_mutexattr_setprotocol/1-1.c
@@ -27,11 +27,6 @@ int main()
 	
 	pthread_mutexattr_t mta;
 	int protocol, protcls[3],i;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support pthread_mutexattr_setprotocol to a nonzero value.\n");
-	exit(0);
-#endif
 	
 	/* Initialize a mutex attributes object */
 	if(pthread_mutexattr_init(&mta) != 0)

--- a/conformance/interfaces/pthread_mutexattr_settype/2-1.c
+++ b/conformance/interfaces/pthread_mutexattr_settype/2-1.c
@@ -44,12 +44,6 @@ int main()
 	pthread_mutex_t mutex;
 	pthread_mutexattr_t mta;
 	int ret;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support interrupting pthread_mutex_lock wait via a SIGALRM.\n");
-	exit(0);
-#endif
-
 	/* Initialize a mutex attributes object */
 	if(pthread_mutexattr_init(&mta) != 0)
 	{

--- a/conformance/interfaces/pthread_once/6-1.c
+++ b/conformance/interfaces/pthread_once/6-1.c
@@ -243,10 +243,6 @@ int main ( int argc, char * argv[] )
 
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
 	/* Initialize output routine */
 	output_init();
 

--- a/conformance/interfaces/pthread_rwlock_rdlock/2-1.c
+++ b/conformance/interfaces/pthread_rwlock_rdlock/2-1.c
@@ -150,11 +150,6 @@ int main()
 	pthread_t rd_thread, wr_thread;
 	int priority;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: musl/Emscripten does not support thread priorities, so cannot test rwlocking in priority order.\n");
-	exit(0);
-#endif
-
 	/* main thread needs to have the highest priority*/
 	priority = sched_get_priority_min(TRD_POLICY) + 2;
 	set_priority(pthread_self(), TRD_POLICY, priority);

--- a/conformance/interfaces/pthread_rwlock_rdlock/2-2.c
+++ b/conformance/interfaces/pthread_rwlock_rdlock/2-2.c
@@ -148,11 +148,6 @@ int main()
 	int cnt = 0;
 	pthread_t rd_thread, wr_thread;
 	int priority;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: musl/Emscripten does not support thread priorities, so cannot test rwlocking in priority order.\n");
-	exit(0);
-#endif
 	
 	/* main thread needs to have the highest priority*/
 	priority = sched_get_priority_min(TRD_POLICY) + 2;

--- a/conformance/interfaces/pthread_rwlock_rdlock/4-1.c
+++ b/conformance/interfaces/pthread_rwlock_rdlock/4-1.c
@@ -95,11 +95,6 @@ int main()
 	int cnt;
 	handler_called = 0;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	if(pthread_rwlock_init(&rwlock, NULL) != 0)
 	{
 		printf("main: Error at pthread_rwlock_init()\n");

--- a/conformance/interfaces/pthread_rwlock_timedrdlock/6-1.c
+++ b/conformance/interfaces/pthread_rwlock_timedrdlock/6-1.c
@@ -115,11 +115,6 @@ int main()
 	int cnt;
 	struct timeval wait_time;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	if(pthread_rwlock_init(&rwlock, NULL) != 0)
 	{
 		printf("Error at pthread_rwlock_init()\n");

--- a/conformance/interfaces/pthread_rwlock_timedrdlock/6-2.c
+++ b/conformance/interfaces/pthread_rwlock_timedrdlock/6-2.c
@@ -131,11 +131,6 @@ int main()
 {
 	int cnt;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	if(pthread_rwlock_init(&rwlock, NULL) != 0)
 	{
 		printf("Error at pthread_rwlock_init()\n");

--- a/conformance/interfaces/pthread_rwlock_timedwrlock/6-1.c
+++ b/conformance/interfaces/pthread_rwlock_timedwrlock/6-1.c
@@ -114,11 +114,6 @@ int main()
 	int cnt;
 	struct timeval time_diff;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	if(pthread_rwlock_init(&rwlock, NULL) != 0)
 	{
 		printf("Error at pthread_rwlock_init()\n");

--- a/conformance/interfaces/pthread_rwlock_timedwrlock/6-2.c
+++ b/conformance/interfaces/pthread_rwlock_timedwrlock/6-2.c
@@ -131,11 +131,6 @@ int main()
 {
 	int cnt;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	if(pthread_rwlock_init(&rwlock, NULL) != 0)
 	{
 		printf("Error at pthread_rwlock_init()\n");

--- a/conformance/interfaces/pthread_rwlock_unlock/3-1.c
+++ b/conformance/interfaces/pthread_rwlock_unlock/3-1.c
@@ -197,11 +197,6 @@ int main()
 	pthread_t writer1, reader, writer2;
 	int priority;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: musl/Emscripten does not support thread priorities, so cannot test rwlocking in priority order.\n");
-	exit(0);
-#endif
-
 	/* main thread needs to have the highest priority*/
 	priority = sched_get_priority_min(TRD_POLICY) + 3;
 	set_priority(pthread_self(), TRD_POLICY, priority);

--- a/conformance/interfaces/pthread_rwlock_wrlock/2-1.c
+++ b/conformance/interfaces/pthread_rwlock_wrlock/2-1.c
@@ -96,11 +96,6 @@ int main()
 	int rc = 0;
 	handler_called=0;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	if(pthread_rwlock_init(&rwlock, NULL) != 0)
 	{
 		printf("Error at pthread_rwlock_init()\n");

--- a/conformance/interfaces/pthread_rwlockattr_getpshared/2-1.c
+++ b/conformance/interfaces/pthread_rwlockattr_getpshared/2-1.c
@@ -51,11 +51,6 @@ int main()
 
 	pthread_rwlockattr_t rwla;
 	int pshared = PTHREAD_PROCESS_SHARED;
-
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support shm_open and shm_unlink.\n");
-	exit(0);
-#endif
 	
 	char shm_name[] = "tmp_pthread_rwlock_getpshared";
 	int shm_fd;

--- a/conformance/interfaces/pthread_setschedparam/5-1.c
+++ b/conformance/interfaces/pthread_setschedparam/5-1.c
@@ -221,11 +221,6 @@ int main ( int argc, char * argv[] )
 
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Initialize output routine */
 	output_init();
 

--- a/conformance/interfaces/pthread_spin_init/2-1.c
+++ b/conformance/interfaces/pthread_spin_init/2-1.c
@@ -48,11 +48,6 @@ int main()
 	  return PTS_UNSUPPORTED;	
 	#endif
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support shm_open and shm_unlink.\n");
-	exit(0);
-#endif
-
 	int pshared = PTHREAD_PROCESS_SHARED;
 	
 	char shm_name[] = "tmp_pthread_spinlock_getpshared";

--- a/conformance/interfaces/pthread_spin_init/2-2.c
+++ b/conformance/interfaces/pthread_spin_init/2-2.c
@@ -62,11 +62,6 @@ int main()
 	int pid;
 	int rc;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support shm_open and shm_unlink.\n");
-	exit(0);
-#endif
-
 	/* Create shared object */
 	shm_unlink(shm_name);
 	shm_fd = shm_open(shm_name, O_RDWR|O_CREAT|O_EXCL, S_IRUSR|S_IWUSR);

--- a/conformance/interfaces/pthread_spin_lock/1-1.c
+++ b/conformance/interfaces/pthread_spin_lock/1-1.c
@@ -101,11 +101,6 @@ int main()
 	void *value_ptr;
 	struct sigaction sa;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Block the SIGALRM signal for main thread */
 	sigemptyset (&sa.sa_mask);
 	sigaddset(&sa.sa_mask, SIGALRM);

--- a/conformance/interfaces/pthread_spin_lock/3-1.c
+++ b/conformance/interfaces/pthread_spin_lock/3-1.c
@@ -38,11 +38,6 @@ int main()
 	pthread_spinlock_t spinlock;
 	struct sigaction act;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: signals are not supported in Emscripten.\n");
-	exit(0);
-#endif
-
 	/* Set up child thread to handle SIGALRM */
 	act.sa_flags = 0;
 	act.sa_handler = sig_handler;

--- a/conformance/interfaces/sem_init/3-2.c
+++ b/conformance/interfaces/sem_init/3-2.c
@@ -98,11 +98,6 @@ int main( int argc, char * argv[] )
 	void *buf;
 	sem_t * sem;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support shm_open and shm_unlink.\n");
-	exit(0);
-#endif
-
 	/* Initialize output */
 	output_init();
 

--- a/conformance/interfaces/sem_init/3-3.c
+++ b/conformance/interfaces/sem_init/3-3.c
@@ -97,11 +97,6 @@ int main( int argc, char * argv[] )
 	void *buf;
 	sem_t * sem;
 
-#ifdef __EMSCRIPTEN__
-	printf("Test SKIPPED: Emscripten does not support shm_open and shm_unlink.\n");
-	exit(0);
-#endif
-
 	/* Initialize output */
 	output_init();
 


### PR DESCRIPTION
This ensures that Emscripten specific changes to the Open POSIX test suite are kept to a minimum.

Depends on: https://github.com/emscripten-core/emscripten/pull/13059.