### PR TITLE
Allow tests to run when min stack size is less than page size

### DIFF
--- a/conformance/interfaces/pthread_create/threads_scenarii.c
+++ b/conformance/interfaces/pthread_create/threads_scenarii.c
@@ -144,10 +144,12 @@ void scenar_init()
 	#endif
 	
 	
+#ifndef __EMSCRIPTEN__
 	if (minstacksize % pagesize)
 	{
 		UNTESTED("The min stack size is not a multiple of the page size");
 	}
+#endif
 	
 	for (i=0; i<NSCENAR; i++)
 	{

--- a/conformance/interfaces/pthread_detach/threads_scenarii.c
+++ b/conformance/interfaces/pthread_detach/threads_scenarii.c
@@ -144,10 +144,12 @@ void scenar_init()
 	#endif
 	
 	
+#ifndef __EMSCRIPTEN__
 	if (minstacksize % pagesize)
 	{
 		UNTESTED("The min stack size is not a multiple of the page size");
 	}
+#endif
 	
 	for (i=0; i<NSCENAR; i++)
 	{

--- a/conformance/interfaces/pthread_exit/threads_scenarii.c
+++ b/conformance/interfaces/pthread_exit/threads_scenarii.c
@@ -144,10 +144,12 @@ void scenar_init()
 	#endif
 	
 	
+#ifndef __EMSCRIPTEN__
 	if (minstacksize % pagesize)
 	{
 		UNTESTED("The min stack size is not a multiple of the page size");
 	}
+#endif
 	
 	for (i=0; i<NSCENAR; i++)
 	{

--- a/conformance/interfaces/pthread_join/threads_scenarii.c
+++ b/conformance/interfaces/pthread_join/threads_scenarii.c
@@ -131,11 +131,12 @@ void scenar_init()
 	output( " min stack size: %li\n", minstacksize );
 #endif
 
-
+#ifndef __EMSCRIPTEN__
 	if ( minstacksize % pagesize )
 	{
 		UNTESTED( "The min stack size is not a multiple of the page size" );
 	}
+#endif
 
 	for ( i = 0; i < NSCENAR; i++ )
 	{

--- a/stress/threads/pthread_create/threads_scenarii.c
+++ b/stress/threads/pthread_create/threads_scenarii.c
@@ -144,10 +144,12 @@ void scenar_init()
 	#endif
 	
 	
+#ifndef __EMSCRIPTEN__
 	if (minstacksize % pagesize)
 	{
 		UNTESTED("The min stack size is not a multiple of the page size");
 	}
+#endif
 	
 	for (i=0; i<NSCENAR; i++)
 	{

--- a/stress/threads/pthread_exit/threads_scenarii.c
+++ b/stress/threads/pthread_exit/threads_scenarii.c
@@ -144,10 +144,12 @@ void scenar_init()
 	#endif
 	
 	
+#ifndef __EMSCRIPTEN__
 	if (minstacksize % pagesize)
 	{
 		UNTESTED("The min stack size is not a multiple of the page size");
 	}
+#endif
 	
 	for (i=0; i<NSCENAR; i++)
 	{

--- a/stress/threads/pthread_self/threads_scenarii.c
+++ b/stress/threads/pthread_self/threads_scenarii.c
@@ -182,10 +182,12 @@ void scenar_init()
 	#endif
 	
 	
+#ifndef __EMSCRIPTEN__
 	if (minstacksize % pagesize)
 	{
 		UNTESTED("The min stack size is not a multiple of the page size");
 	}
+#endif
 	
 	for (i=0; i<NSCENAR; i++)
 	{


### PR DESCRIPTION
We would like this to be possible under WebAssembly/emscripten
which has a pretty high page size (64k).

IIRC these check are really about saying that the tests have
not themselves been verified under such conditions and not about
the pthread spec containing such a requirement.

I verified that all these tests run fine with stack size of 2k
under emscripten.