### PR TITLE
Fix race in conformance/interfaces/pthread_mutex_init/1-2.c

### DIFF
--- a/conformance/interfaces/pthread_mutex_init/1-2.c
+++ b/conformance/interfaces/pthread_mutex_init/1-2.c
@@ -114,13 +114,13 @@ void * deadlk_issue(void * arg)
 	{ UNRESOLVED(ret, "Set cancel type in deadlk_issue"); }
 	if ((ret = pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &tmp)))
 	{ UNRESOLVED(ret, "Set cancel state in deadlk_issue"); }
+    	returned = 0;
 	#if VERBOSE >1
 	output("Thread releases the semaphore...\n");
 	#endif
 	if ((ret = sem_post(&semA)))
 	{ UNRESOLVED(errno, "Sem_post in deadlk_issue"); }
     
-    	returned = 0;
 	retval = pthread_mutex_lock(p_mtx);
 	returned = 1;
 


### PR DESCRIPTION
This test was running deadlk_issue several times and expecting the
returned global to be zero if `pthread_mutex_lock` has not returned,
however the resetting on `returned` to zero was happening only after the
`sem_post`.  The main thread is calling `sched_yeild` which on most
platforms is enough to cover up this issue, but not with WebAssembly.

Some alternatives to landing this change:

1. We could just disable this test.
2. We could make sched_yield actualy do something rather than be
   a no-op.