### PR TITLE
Fix pthread_kill() on fast computers

### DIFF
--- a/conformance/interfaces/pthread_cancel/5-2.c
+++ b/conformance/interfaces/pthread_cancel/5-2.c
@@ -43,6 +43,10 @@
 #include <errno.h>
 #include <signal.h>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 /********************************************************************************************/
 /******************************   Test framework   *****************************************/
 /********************************************************************************************/
@@ -138,6 +142,14 @@ void * sendsig ( void * arg )
 		{
 			UNRESOLVED( errno, "Kill in sendsig" );
 		}
+
+#ifdef __EMSCRIPTEN__
+		// Throttle this loop so it won't spam a large number of pthread_kill()
+		// events over to the main thread. Each pthread_kill() needs to allocate
+		// memory, which will run in an OOM on a fast CPU, before the main thread
+		// might be able to react.
+		EM_ASM(Atomics.wait(HEAP32, 0, HEAP32[0], 1));
+#endif
 
 	}
 

--- a/conformance/interfaces/pthread_cond_init/4-2.c
+++ b/conformance/interfaces/pthread_cond_init/4-2.c
@@ -44,6 +44,10 @@
  #include <stdio.h>
  #include <stdarg.h>
  #include <stdlib.h>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
  
 /********************************************************************************************/
 /******************************   Test framework   *****************************************/
@@ -117,7 +121,15 @@ void * sendsig (void * arg)
 
 		if ((ret = pthread_kill (*(thearg->thr), thearg->sig)))
 		{ UNRESOLVED(ret, "Pthread_kill in sendsig"); }
-		
+
+#ifdef __EMSCRIPTEN__
+		// Throttle this loop so it won't spam a large number of pthread_kill()
+		// events over to the main thread. Each pthread_kill() needs to allocate
+		// memory, which will run in an OOM on a fast CPU, before the main thread
+		// might be able to react.
+		EM_ASM(Atomics.wait(HEAP32, 0, HEAP32[0], 1));
+#endif
+
 	}
 	
 	return NULL;

--- a/conformance/interfaces/pthread_kill/8-1.c
+++ b/conformance/interfaces/pthread_kill/8-1.c
@@ -43,6 +43,10 @@
  #include <errno.h>
  #include <signal.h>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 /********************************************************************************************/
 /******************************   Test framework   *****************************************/
 /********************************************************************************************/
@@ -221,6 +225,13 @@ void * test( void * arg )
 		{
 			UNRESOLVED( ret, "pthread_kill returned an unexpected error" );
 		}
+#ifdef __EMSCRIPTEN__
+		// Throttle this loop so it won't spam a large number of pthread_kill()
+		// events over to the main thread. Each pthread_kill() needs to allocate
+		// memory, which will run in an OOM on a fast CPU, before the main thread
+		// might be able to react.
+		EM_ASM(Atomics.wait(HEAP32, 0, HEAP32[0], 1));
+#endif
 	}
 
 	return NULL;

--- a/conformance/interfaces/pthread_mutex_init/5-3.c
+++ b/conformance/interfaces/pthread_mutex_init/5-3.c
@@ -53,6 +53,10 @@
  #include <stdio.h>
  #include <stdarg.h>
  #include <stdlib.h>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
  
 /********************************************************************************************/
 /******************************   Test framework   *****************************************/
@@ -126,6 +130,14 @@ void * sendsig (void * arg)
 
 		if ((ret = pthread_kill (*(thearg->thr), thearg->sig)))
 		{ UNRESOLVED(ret, "Pthread_kill in sendsig"); }
+
+#ifdef __EMSCRIPTEN__
+		// Throttle this loop so it won't spam a large number of pthread_kill()
+		// events over to the main thread. Each pthread_kill() needs to allocate
+		// memory, which will run in an OOM on a fast CPU, before the main thread
+		// might be able to react.
+		EM_ASM(Atomics.wait(HEAP32, 0, HEAP32[0], 1));
+#endif
 		
 	}
 	

--- a/conformance/interfaces/pthread_mutex_lock/3-1.c
+++ b/conformance/interfaces/pthread_mutex_lock/3-1.c
@@ -54,6 +54,10 @@
  #include <stdlib.h>
  #include <stdio.h>
  #include <stdarg.h>
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
  
 /********************************************************************************************/
 /******************************   Test framework   *****************************************/
@@ -127,7 +131,15 @@ void * sendsig (void * arg)
 
 		if ((ret = pthread_kill (*(thearg->thr), thearg->sig)))
 		{ UNRESOLVED(ret, "Pthread_kill in sendsig"); }
-		
+	
+#ifdef __EMSCRIPTEN__
+		// Throttle this loop so it won't spam a large number of pthread_kill()
+		// events over to the main thread. Each pthread_kill() needs to allocate
+		// memory, which will run in an OOM on a fast CPU, before the main thread
+		// might be able to react.
+		EM_ASM(Atomics.wait(HEAP32, 0, HEAP32[0], 1));
+#endif
+
 	}
 	
 	return NULL;


### PR DESCRIPTION
pthread_kill() allocates memory, so on a fast computer, it could OOM the test suite before the main thread is able to react. Throttle unbounded pthread_kill() loops.