### PR TITLE
Remove incorrect assertion in conformance/interfaces/pthread_cancel/3-1.c

### DIFF
--- a/conformance/interfaces/pthread_cancel/3-1.c
+++ b/conformance/interfaces/pthread_cancel/3-1.c
@@ -146,12 +146,21 @@ int main()
 		exit(PTS_FAIL);
 	}
 	
+#ifndef __EMSCRIPTEN__
+	// The assertion here that the cleanup function should not be run before
+	// pthread_cancel returns seems wrong.  I've seen this fail in emscripten since
+	// the cancelation signal can be received and acted upon by the receiver
+	// before `pthread_cancel` returns.
+	// On an SMP system with more than one core setting the main thread priority
+	// to `MAIN_PRIORITY` does not prevent the child thread (running on a separate
+	// core) from performing the cleanup functions before `pthread_cancel` returns.
 	diff = cleanup_time.tv_sec - main_time.tv_sec;
 	diff += (double)(cleanup_time.tv_nsec - main_time.tv_nsec)/1000000000.0;
 	if(diff < 0) {
 		printf(ERROR_PREFIX "Cleanup function was called before main continued\n");
 		exit(PTS_FAIL);
 	}
+#endif
 	printf("Test PASS\n");
 	exit(PTS_PASS);	
 }


### PR DESCRIPTION
I believe the assertion here is incorrect.  Gemini seems to agree with me:

The assertion if (diff < 0) and the corresponding error message "Cleanup function was called before main continued" appear to be incorrect or at least overly restrictive for a POSIX conformance test.

Analysis of the Logic:

   1. Thread Priorities: The test sets the main thread to a higher priority (SCHED_FIFO, priority 30) than the target thread. On a single-processor system, this would typically ensure that the target thread does not run until the main thread blocks (e.g., at sleep(1)).
   2. Execution Flow:
       * Main calls pthread_cancel(new_th).
       * Main immediately calls clock_gettime to record main_time. * The target thread (at some point) is cancelled and runs a_cleanup_func, which records cleanup_time.
   3. The Assertion: The test fails if cleanup_time < main_time.

Why the Assertion is Problematic:

   * SMP (Symmetric Multi-Processing): On a multi-core system, the target thread can be running on a different core. When pthread_cancel is called, the cancellation request can be acted upon almost immediately. It is entirely possible for the cleanup handler to execute and record its timestamp before the main thread returns from pthread_cancel and records its own timestamp.
   * POSIX Requirements: POSIX defines pthread_cancel as a request. It specifies that the function returns after the request has been successfully made. It does not guarantee that the caller will continue execution before the target thread starts its cleanup handlers. In fact, in PTHREAD_CANCEL_ASYNCHRONOUS mode, the cancellation is intended to be acted upon "at any time."
   * Valid Behavior Labeled as Failure: The error message "Cleanup function was called before main continued" describes a perfectly valid execution sequence. If the cleanup handler runs "too fast," the test fails, even though the primary goal of the test (verifying that the cleanup handler is called) was successfully achieved.

Conclusion:

  The assertion seems to be based on an assumption of single-processor
  behavior or an unintended requirement for specific thread
  interleaving. For a robust conformance test, diff < 0 should not be a
  failure condition, as it doesn't violate any POSIX requirement. The
  test should instead focus on whether the cleanup handler was called at
  all and whether it was called as a result of the cancellation.