### PR TITLE
Limit the number of created pthreads in detach/4-3.c and create/14-1.c

### DIFF
--- a/conformance/interfaces/pthread_create/14-1.c
+++ b/conformance/interfaces/pthread_create/14-1.c
@@ -246,6 +246,16 @@ void * test(void * arg)
 		
 		/* Change thread attribute for the next loop */
 		sc++;
+
+#ifdef __EMSCRIPTEN__
+		// XXX Emscripten: originally this test would spawn threads for one second,
+		// until main thread latches `do_it = 0;`. The threads would then loop the
+		// number of test cases. For Emscripten, since # of synchronously spawnable
+		// threads is a limited resource, do not allow runaway thread creation, but
+		// instead test each scenario exactly once.
+		if (sc >= NSCENAR) break;
+#endif
+
 		sc %= NSCENAR;
 	}
 	return NULL;

--- a/conformance/interfaces/pthread_detach/4-3.c
+++ b/conformance/interfaces/pthread_detach/4-3.c
@@ -242,6 +242,16 @@ void * test(void * arg)
 		
 		/* Change thread attribute for the next loop */
 		sc++;
+
+#ifdef __EMSCRIPTEN__
+		// XXX Emscripten: originally this test would spawn threads for one second,
+		// until main thread latches `do_it = 0;`. The threads would then loop the
+		// number of test cases. For Emscripten, since # of synchronously spawnable
+		// threads is a limited resource, do not allow runaway thread creation, but
+		// instead test each scenario exactly once.
+		if (sc >= NSCENAR) break;
+#endif
+
 		sc %= NSCENAR;
 	}
 	return NULL;


### PR DESCRIPTION
Limit the number of created pthreads in detach/4-3.c and create/14-1.c to avoid runaway thread spawning. Fixes posixtest_browser.test_pthread_detach_4_3 from hanging.

http://clbri.com:8010/api/v2/logs/394981/raw_inline