### PR TITLE
Fix stale POSIX.1-2001 version gate in aio_*/lio_listio tests

### DIFF
--- a/conformance/interfaces/aio_cancel/1-1.c
+++ b/conformance/interfaces/aio_cancel/1-1.c
@@ -42,7 +42,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_cancel/10-1.c
+++ b/conformance/interfaces/aio_cancel/10-1.c
@@ -34,7 +34,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_cancel/2-1.c
+++ b/conformance/interfaces/aio_cancel/2-1.c
@@ -47,7 +47,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_cancel/2-2.c
+++ b/conformance/interfaces/aio_cancel/2-2.c
@@ -41,7 +41,7 @@ int main()
 	char tmpfname[256];
 	int fd;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_cancel/3-1.c
+++ b/conformance/interfaces/aio_cancel/3-1.c
@@ -72,7 +72,7 @@ int main()
 	struct sigaction action;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_cancel/4-1.c
+++ b/conformance/interfaces/aio_cancel/4-1.c
@@ -53,7 +53,7 @@ int main()
 	int i;
 	int in_progress;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_cancel/5-1.c
+++ b/conformance/interfaces/aio_cancel/5-1.c
@@ -53,7 +53,7 @@ int main()
 	int in_progress;
 	static int check_one;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_cancel/6-1.c
+++ b/conformance/interfaces/aio_cancel/6-1.c
@@ -55,7 +55,7 @@ int main()
 	int in_progress;
 	int gret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_cancel/7-1.c
+++ b/conformance/interfaces/aio_cancel/7-1.c
@@ -53,7 +53,7 @@ int main()
 	int in_progress;
 	int gret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_cancel/8-1.c
+++ b/conformance/interfaces/aio_cancel/8-1.c
@@ -44,7 +44,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_cancel/9-1.c
+++ b/conformance/interfaces/aio_cancel/9-1.c
@@ -35,7 +35,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_error/1-1.c
+++ b/conformance/interfaces/aio_error/1-1.c
@@ -42,7 +42,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_error/2-1.c
+++ b/conformance/interfaces/aio_error/2-1.c
@@ -47,7 +47,7 @@ int main()
 	int i;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_error/3-1.c
+++ b/conformance/interfaces/aio_error/3-1.c
@@ -39,7 +39,7 @@ int main()
 	struct aiocb bad;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	return PTS_UNSUPPORTED;
 #endif
 

--- a/conformance/interfaces/aio_fsync/1-1.c
+++ b/conformance/interfaces/aio_fsync/1-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/10-1.c
+++ b/conformance/interfaces/aio_fsync/10-1.c
@@ -29,7 +29,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/11-1.c
+++ b/conformance/interfaces/aio_fsync/11-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/12-1.c
+++ b/conformance/interfaces/aio_fsync/12-1.c
@@ -24,7 +24,7 @@
 int main()
 {
 	struct aiocb aiocb;
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/13-1.c
+++ b/conformance/interfaces/aio_fsync/13-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/14-1.c
+++ b/conformance/interfaces/aio_fsync/14-1.c
@@ -30,7 +30,7 @@ int main()
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/2-1.c
+++ b/conformance/interfaces/aio_fsync/2-1.c
@@ -31,7 +31,7 @@ int main()
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/3-1.c
+++ b/conformance/interfaces/aio_fsync/3-1.c
@@ -31,7 +31,7 @@ int main()
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/4-1.c
+++ b/conformance/interfaces/aio_fsync/4-1.c
@@ -30,7 +30,7 @@ int main()
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/4-2.c
+++ b/conformance/interfaces/aio_fsync/4-2.c
@@ -30,7 +30,7 @@ int main()
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/5-1.c
+++ b/conformance/interfaces/aio_fsync/5-1.c
@@ -32,7 +32,7 @@ int main()
 	struct aiocb aiocb_fsync;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/6-1.c
+++ b/conformance/interfaces/aio_fsync/6-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/7-1.c
+++ b/conformance/interfaces/aio_fsync/7-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/8-1.c
+++ b/conformance/interfaces/aio_fsync/8-1.c
@@ -30,7 +30,7 @@ int main()
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/8-2.c
+++ b/conformance/interfaces/aio_fsync/8-2.c
@@ -30,7 +30,7 @@ int main()
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/8-3.c
+++ b/conformance/interfaces/aio_fsync/8-3.c
@@ -30,7 +30,7 @@ int main()
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/8-4.c
+++ b/conformance/interfaces/aio_fsync/8-4.c
@@ -30,7 +30,7 @@ int main()
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_fsync/9-1.c
+++ b/conformance/interfaces/aio_fsync/9-1.c
@@ -30,7 +30,7 @@ int main()
 	struct aiocb aiocb_write;
 	struct aiocb aiocb_fsync;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/1-1.c
+++ b/conformance/interfaces/aio_read/1-1.c
@@ -44,7 +44,7 @@ int main()
 
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/10-1.c
+++ b/conformance/interfaces/aio_read/10-1.c
@@ -41,7 +41,7 @@ int main()
 	char buf[BUF_SIZE];
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/11-1.c
+++ b/conformance/interfaces/aio_read/11-1.c
@@ -44,7 +44,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/11-2.c
+++ b/conformance/interfaces/aio_read/11-2.c
@@ -44,7 +44,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/12-1.c
+++ b/conformance/interfaces/aio_read/12-1.c
@@ -30,7 +30,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/13-1.c
+++ b/conformance/interfaces/aio_read/13-1.c
@@ -29,7 +29,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/14-1.c
+++ b/conformance/interfaces/aio_read/14-1.c
@@ -30,7 +30,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/15-1.c
+++ b/conformance/interfaces/aio_read/15-1.c
@@ -35,7 +35,7 @@ int main()
 	struct aiocb aiocb;
 	struct rlimit limit;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/2-1.c
+++ b/conformance/interfaces/aio_read/2-1.c
@@ -29,7 +29,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/3-1.c
+++ b/conformance/interfaces/aio_read/3-1.c
@@ -41,7 +41,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/3-2.c
+++ b/conformance/interfaces/aio_read/3-2.c
@@ -41,7 +41,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/4-1.c
+++ b/conformance/interfaces/aio_read/4-1.c
@@ -43,7 +43,7 @@ int main()
 	struct aiocb aiocb;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/5-1.c
+++ b/conformance/interfaces/aio_read/5-1.c
@@ -44,7 +44,7 @@ int main()
 	struct aiocb aiocb;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/6-1.c
+++ b/conformance/interfaces/aio_read/6-1.c
@@ -29,7 +29,7 @@
 int main()
 {
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/7-1.c
+++ b/conformance/interfaces/aio_read/7-1.c
@@ -42,7 +42,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/8-1.c
+++ b/conformance/interfaces/aio_read/8-1.c
@@ -38,7 +38,7 @@ int main()
 {
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_read/9-1.c
+++ b/conformance/interfaces/aio_read/9-1.c
@@ -49,7 +49,7 @@ int main()
 	int err;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_return/1-1.c
+++ b/conformance/interfaces/aio_return/1-1.c
@@ -44,7 +44,7 @@ int main()
 	struct aiocb aiocb;
 	int retval;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_return/2-1.c
+++ b/conformance/interfaces/aio_return/2-1.c
@@ -41,7 +41,7 @@ int main()
 	struct aiocb aiocb;
 	int retval;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_return/3-1.c
+++ b/conformance/interfaces/aio_return/3-1.c
@@ -47,7 +47,7 @@ int main()
 	struct aiocb aiocb;
 	int retval;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_return/3-2.c
+++ b/conformance/interfaces/aio_return/3-2.c
@@ -45,7 +45,7 @@ int main()
 	struct aiocb aiocb;
 	int retval;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_return/4-1.c
+++ b/conformance/interfaces/aio_return/4-1.c
@@ -44,7 +44,7 @@ int main()
 	struct aiocb aiocb2;
 	int retval;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_suspend/1-1.c
+++ b/conformance/interfaces/aio_suspend/1-1.c
@@ -73,7 +73,7 @@ main ()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_suspend/2-1.c
+++ b/conformance/interfaces/aio_suspend/2-1.c
@@ -27,7 +27,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_suspend/3-1.c
+++ b/conformance/interfaces/aio_suspend/3-1.c
@@ -47,7 +47,7 @@ int main()
 	const struct aiocb *list[NENT];
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_suspend/4-1.c
+++ b/conformance/interfaces/aio_suspend/4-1.c
@@ -71,7 +71,7 @@ main ()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_suspend/5-1.c
+++ b/conformance/interfaces/aio_suspend/5-1.c
@@ -26,7 +26,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_suspend/6-1.c
+++ b/conformance/interfaces/aio_suspend/6-1.c
@@ -69,7 +69,7 @@ main ()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_suspend/7-1.c
+++ b/conformance/interfaces/aio_suspend/7-1.c
@@ -71,7 +71,7 @@ main ()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_suspend/8-1.c
+++ b/conformance/interfaces/aio_suspend/8-1.c
@@ -74,7 +74,7 @@ main ()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_suspend/9-1.c
+++ b/conformance/interfaces/aio_suspend/9-1.c
@@ -71,7 +71,7 @@ main ()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/1-1.c
+++ b/conformance/interfaces/aio_write/1-1.c
@@ -47,7 +47,7 @@ int main()
 	int err;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/1-2.c
+++ b/conformance/interfaces/aio_write/1-2.c
@@ -48,7 +48,7 @@ int main()
 	int err;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/10-1.c
+++ b/conformance/interfaces/aio_write/10-1.c
@@ -28,7 +28,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/11-1.c
+++ b/conformance/interfaces/aio_write/11-1.c
@@ -28,7 +28,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/12-1.c
+++ b/conformance/interfaces/aio_write/12-1.c
@@ -27,7 +27,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/13-1.c
+++ b/conformance/interfaces/aio_write/13-1.c
@@ -29,7 +29,7 @@
 int main()
 {
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/2-1.c
+++ b/conformance/interfaces/aio_write/2-1.c
@@ -55,7 +55,7 @@ int main()
 	int err;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/3-1.c
+++ b/conformance/interfaces/aio_write/3-1.c
@@ -47,7 +47,7 @@ int main()
 	int err;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/4-1.c
+++ b/conformance/interfaces/aio_write/4-1.c
@@ -29,7 +29,7 @@
 int main()
 {
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/5-1.c
+++ b/conformance/interfaces/aio_write/5-1.c
@@ -45,7 +45,7 @@ int main()
 	int err;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/6-1.c
+++ b/conformance/interfaces/aio_write/6-1.c
@@ -39,7 +39,7 @@ int main()
 {
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/7-1.c
+++ b/conformance/interfaces/aio_write/7-1.c
@@ -49,7 +49,7 @@ int main()
 	int err;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/8-1.c
+++ b/conformance/interfaces/aio_write/8-1.c
@@ -41,7 +41,7 @@ int main()
 	char buf[BUF_SIZE];
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/8-2.c
+++ b/conformance/interfaces/aio_write/8-2.c
@@ -43,7 +43,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/9-1.c
+++ b/conformance/interfaces/aio_write/9-1.c
@@ -46,7 +46,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/aio_write/9-2.c
+++ b/conformance/interfaces/aio_write/9-2.c
@@ -46,7 +46,7 @@ int main()
 	int fd;
 	struct aiocb aiocb;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/1-1.c
+++ b/conformance/interfaces/lio_listio/1-1.c
@@ -65,7 +65,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/10-1.c
+++ b/conformance/interfaces/lio_listio/10-1.c
@@ -64,7 +64,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/11-1.c
+++ b/conformance/interfaces/lio_listio/11-1.c
@@ -64,7 +64,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/12-1.c
+++ b/conformance/interfaces/lio_listio/12-1.c
@@ -47,7 +47,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/13-1.c
+++ b/conformance/interfaces/lio_listio/13-1.c
@@ -47,7 +47,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/14-1.c
+++ b/conformance/interfaces/lio_listio/14-1.c
@@ -64,7 +64,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/15-1.c
+++ b/conformance/interfaces/lio_listio/15-1.c
@@ -64,7 +64,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/16-1.c
+++ b/conformance/interfaces/lio_listio/16-1.c
@@ -28,7 +28,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/17-1.c
+++ b/conformance/interfaces/lio_listio/17-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/18-1.c
+++ b/conformance/interfaces/lio_listio/18-1.c
@@ -45,7 +45,7 @@ int main()
 	char *bufs;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/19-1.c
+++ b/conformance/interfaces/lio_listio/19-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/2-1.c
+++ b/conformance/interfaces/lio_listio/2-1.c
@@ -63,7 +63,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/20-1.c
+++ b/conformance/interfaces/lio_listio/20-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/21-1.c
+++ b/conformance/interfaces/lio_listio/21-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/22-1.c
+++ b/conformance/interfaces/lio_listio/22-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/23-1.c
+++ b/conformance/interfaces/lio_listio/23-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/24-1.c
+++ b/conformance/interfaces/lio_listio/24-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/25-1.c
+++ b/conformance/interfaces/lio_listio/25-1.c
@@ -15,7 +15,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/3-1.c
+++ b/conformance/interfaces/lio_listio/3-1.c
@@ -64,7 +64,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/4-1.c
+++ b/conformance/interfaces/lio_listio/4-1.c
@@ -64,7 +64,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/5-1.c
+++ b/conformance/interfaces/lio_listio/5-1.c
@@ -53,7 +53,7 @@ int main()
 	int i;
 
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/6-1.c
+++ b/conformance/interfaces/lio_listio/6-1.c
@@ -34,7 +34,7 @@
 
 int main()
 {
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/7-1.c
+++ b/conformance/interfaces/lio_listio/7-1.c
@@ -67,7 +67,7 @@ int main()
 	int err;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/8-1.c
+++ b/conformance/interfaces/lio_listio/8-1.c
@@ -48,7 +48,7 @@ int main()
 	int err;
 	int ret;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 

--- a/conformance/interfaces/lio_listio/9-1.c
+++ b/conformance/interfaces/lio_listio/9-1.c
@@ -49,7 +49,7 @@ int main()
 	int ret;
 	int i;
 
-#if _POSIX_ASYNCHRONOUS_IO != 200112L
+#if _POSIX_ASYNCHRONOUS_IO < 200112L
 	exit(PTS_UNSUPPORTED);
 #endif
 


### PR DESCRIPTION
Fixes #15.

All 104 files under `aio_cancel`/`aio_error`/`aio_fsync`/`aio_read`/`aio_return`/`aio_suspend`/`aio_write`/`lio_listio` guarded on `#if _POSIX_ASYNCHRONOUS_IO != 200112L`, which trips `PTS_UNSUPPORTED` on any POSIX.1-2008 libc (glibc/musl both report `200809L`) regardless of whether AIO actually works.

Changed to `< 200112L`, so any positive/supported value passes and only the real "unsupported" sentinel trips the exit — same idiom used elsewhere in this suite (`_POSIX_MEMLOCK != 0`, `_POSIX_CPUTIME != -1`).

Same one-line change repeated identically across all 104 files — applied with a single `sed` pass rather than hand-editing each one.

Claude Code was used in the creation of this PR. The fix has been reviewed and should work.